### PR TITLE
0.16

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -181,7 +181,7 @@ public:
     std::map<COutPoint, int> mapMasternodesLastVote;
     std::map<COutPoint, int> mapMasternodesDidNotVote;
 
-    CMasternodePayments() : nStorageCoeff(1.25), nMinBlocksToStore(2000) {}
+    CMasternodePayments() : nStorageCoeff(1.25), nMinBlocksToStore(5000) {}
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1986,7 +1986,7 @@ void CConnman::ThreadMnbRequestConnections()
         std::pair<CService, std::set<uint256> > p = mnodeman.PopScheduledMnbRequestConnection();
         if(p.first == CService() || p.second.empty()) continue;
 
-        OpenNetworkConnection(CAddress(p.first, NODE_NONE), false, &grant, nullptr, false, false, true, true, p.second);
+        OpenNetworkConnection(CAddress(p.first, NODE_NETWORK), false, &grant, nullptr, false, false, false, true, p.second);
         if (!interruptNet.sleep_for(std::chrono::milliseconds(1000)))
             return;
     }


### PR DESCRIPTION
- fixed issue, which cause the block sync process to stop (could be solved by restarting Machinecoin)